### PR TITLE
feat: add header for metadata api sdk

### DIFF
--- a/go/http/const.go
+++ b/go/http/const.go
@@ -13,4 +13,6 @@ const (
 	HTTPHeaderDate          = "X-Gnfd-Date"
 	HTTPHeaderRange         = "Range"
 	HTTPHeaderContentSHA256 = "X-Gnfd-Content-Sha256"
+
+	HTTPHeaderUserAddress = "X-Gnfd-User-Address"
 )

--- a/go/http/gen_sign_str.go
+++ b/go/http/gen_sign_str.go
@@ -13,7 +13,7 @@ import (
 
 var supportHeads = []string{
 	HTTPHeaderContentSHA256, HTTPHeaderTransactionHash, HTTPHeaderObjectID, HTTPHeaderRedundancyIndex, HTTPHeaderResource,
-	HTTPHeaderDate, HTTPHeaderRange, HTTPHeaderPieceIndex, HTTPHeaderContentType, HTTPHeaderContentMD5, HTTPHeaderUnsignedMsg,
+	HTTPHeaderDate, HTTPHeaderRange, HTTPHeaderPieceIndex, HTTPHeaderContentType, HTTPHeaderContentMD5, HTTPHeaderUnsignedMsg, HTTPHeaderUserAddress,
 }
 
 // getCanonicalHeaders generate a list of request headers with their values


### PR DESCRIPTION
### Description

Add header for metadata api sdk

### Rationale

HTTPHeaderUserAddress pass in user address for ListBuckets

### Example

Equivalent curl for ListBuckets:
curl --location 'http://gf-sp-a-bk.dev.nodereal.cc/'
--header 'Authorization: authTypeV2 ECDSA-secp256k1, Signature=1234567812345678123456781234567812345678123456781234567812345678' --header 'X-Gnfd-User-Address: xxx'

### Changes

Notable changes:
add header HTTPHeaderUserAddress 