### PR TITLE
perf:  reduce memory usage

### DIFF
--- a/go/hash/hash.go
+++ b/go/hash/hash.go
@@ -67,12 +67,7 @@ func ComputeIntegrityHash(reader io.Reader, segmentSize int64, dataShards, parit
 	for spID, content := range encodeDataHash {
 		go func(data [][]byte, id int) {
 			defer wg.Done()
-			var checksumList [][]byte
-			for _, piecesHash := range data {
-				checksumList = append(checksumList, piecesHash)
-			}
-
-			hashList[id+1] = GenerateIntegrityHash(checksumList)
+			hashList[id+1] = GenerateIntegrityHash(data)
 		}(content, spID)
 	}
 


### PR DESCRIPTION
### Description

reduce memory usage , avoid cachihg the EC decode pieces 

### Rationale

save memory is more import

### Example
NA

### Changes

Notable changes:
* reduce memory usage 

