### PR TITLE
feat: support parallel hash computing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,26 +63,3 @@ jobs:
         working-directory: ./go
         run: make test
 
-  coverage:
-    name: Golang Code Coverage
-    strategy:
-      matrix:
-        go-version: [ 1.18.x ]
-        os: [ ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup GitHub Token
-        run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: Run coverage
-        working-directory: ./go
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v3
-#        with:
-#          files: go/coverage.txt
-#          flags: go
-#          fail_ci_if_error: true

--- a/go/hash/checksum.go
+++ b/go/hash/checksum.go
@@ -6,6 +6,11 @@ import (
 	"fmt"
 )
 
+type SegmentInfo struct {
+	SegmentId int
+	Data      []byte
+}
+
 // GenerateChecksum generates the checksum of one piece data
 func GenerateChecksum(pieceData []byte) []byte {
 	hash := sha256.New()

--- a/go/hash/checksum.go
+++ b/go/hash/checksum.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SegmentInfo struct {
-	SegmentId int
+	SegmentID int
 	Data      []byte
 }
 

--- a/go/hash/hash.go
+++ b/go/hash/hash.go
@@ -3,8 +3,10 @@ package hash
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"sync"
 
 	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
@@ -12,6 +14,12 @@ import (
 
 	"github.com/bnb-chain/greenfield-common/go/redundancy"
 )
+
+const maxThreadNum = 5
+
+type ComputeHashOption struct {
+	mutex *sync.Mutex
+}
 
 // IntegrityHasher compute integrityHash
 type IntegrityHasher struct {
@@ -179,16 +187,9 @@ func ComputeIntegrityHash(reader io.Reader, segmentSize int64, dataShards, parit
 			// compute segment hash
 			checksum := GenerateChecksum(data)
 			segChecksumList = append(segChecksumList, checksum)
-			// get erasure encode bytes
-			encodeShards, err := redundancy.EncodeRawSegment(data, dataShards, parityShards)
-			if err != nil {
-				return nil, 0, storageTypes.REDUNDANCY_EC_TYPE, err
-			}
 
-			for index, shard := range encodeShards {
-				// compute hash of pieces
-				piecesHash := GenerateChecksum(shard)
-				encodeDataHash[index] = append(encodeDataHash[index], piecesHash)
+			if err = encodeAndComputeHash(encodeDataHash, data, dataShards, parityShards); err != nil {
+				return nil, 0, storageTypes.REDUNDANCY_EC_TYPE, err
 			}
 		}
 	}
@@ -212,6 +213,22 @@ func ComputeIntegrityHash(reader io.Reader, segmentSize int64, dataShards, parit
 	return hashList, contentLen, storageTypes.REDUNDANCY_EC_TYPE, nil
 }
 
+func encodeAndComputeHash(encodeDataHash [][][]byte, segment []byte, dataShards, parityShards int) error {
+	// get erasure encode bytes
+	encodeShards, err := redundancy.EncodeRawSegment(segment, dataShards, parityShards)
+	if err != nil {
+		return err
+	}
+
+	for index, shard := range encodeShards {
+		// compute hash of pieces
+		piecesHash := GenerateChecksum(shard)
+		encodeDataHash[index] = append(encodeDataHash[index], piecesHash)
+	}
+
+	return nil
+}
+
 // ComputerHashFromFile open a local file and compute hash result and segmentSize
 func ComputerHashFromFile(filePath string, segmentSize int64, dataShards, parityShards int) ([][]byte, int64, storageTypes.RedundancyType, error) {
 	f, err := os.Open(filePath)
@@ -228,4 +245,136 @@ func ComputerHashFromFile(filePath string, segmentSize int64, dataShards, parity
 func ComputerHashFromBuffer(content []byte, segmentSize int64, dataShards, parityShards int) ([][]byte, int64, storageTypes.RedundancyType, error) {
 	reader := bytes.NewReader(content)
 	return ComputeIntegrityHash(reader, segmentSize, dataShards, parityShards)
+}
+
+func computePieceHashes(segment []byte, dataShards, parityShards int) ([][]byte, error) {
+	// get erasure encode bytes
+	encodeShards, err := redundancy.EncodeRawSegment(segment, dataShards, parityShards)
+	if err != nil {
+		return nil, err
+	}
+
+	var pieceChecksumList [][]byte
+	for _, shard := range encodeShards {
+		// compute hash of pieces
+		piecesHash := GenerateChecksum(shard)
+		pieceChecksumList = append(pieceChecksumList, piecesHash)
+	}
+
+	return pieceChecksumList, nil
+}
+
+func hashWorker(jobs <-chan SegmentInfo, errChan chan<- error, dataShards, parityShards int, wg *sync.WaitGroup, checksumMap *sync.Map, pieceHashMap *sync.Map) {
+	defer wg.Done()
+
+	for segInfo := range jobs {
+		checksum := GenerateChecksum(segInfo.Data)
+		checksumMap.Store(segInfo.SegmentId, checksum)
+
+		pieceCheckSumList, err := computePieceHashes(segInfo.Data, dataShards, parityShards)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		pieceHashMap.Store(segInfo.SegmentId, pieceCheckSumList)
+	}
+}
+
+func ComputeIntegrityHashParallel(reader io.Reader, segmentSize int64, dataShards, parityShards int) ([][]byte, int64, storageTypes.RedundancyType, error) {
+	var (
+		segChecksumList [][]byte
+		ecShards        = dataShards + parityShards
+		contentLen      = int64(0)
+		wg              sync.WaitGroup
+	)
+
+	segHashMap := &sync.Map{}
+	pieceHashMap := &sync.Map{}
+	encodeDataHash := make([][][]byte, ecShards)
+
+	hashList := make([][]byte, ecShards+1)
+
+	jobChan := make(chan SegmentInfo, 100)
+	errChan := make(chan error, 1)
+	// the thread num should be less than maxThreadNum
+	threadNum := runtime.NumCPU() / 2
+	if threadNum > maxThreadNum {
+		threadNum = maxThreadNum
+	}
+	// start workers to compute hash of each segment
+	for i := 0; i < threadNum; i++ {
+		wg.Add(1)
+		go hashWorker(jobChan, errChan, dataShards, parityShards, &wg, segHashMap, pieceHashMap)
+	}
+
+	jobNum := 0
+	for {
+		seg := make([]byte, segmentSize)
+		n, err := reader.Read(seg)
+		if err != nil {
+			if err != io.EOF {
+				log.Error().Msg("failed to read content:" + err.Error())
+				return nil, 0, storageTypes.REDUNDANCY_EC_TYPE, err
+			}
+			break
+		}
+
+		if n > 0 && n <= int(segmentSize) {
+			contentLen += int64(n)
+			data := seg[:n]
+			// compute segment hash
+
+			jobChan <- SegmentInfo{SegmentId: jobNum, Data: data}
+			jobNum++
+		}
+	}
+	close(jobChan)
+
+	for i := 0; i < ecShards; i++ {
+		encodeDataHash[i] = make([][]byte, jobNum)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// check error
+	for err := range errChan {
+		if err != nil {
+			log.Error().Msg("err chan detected err:" + err.Error())
+			return nil, 0, storageTypes.REDUNDANCY_EC_TYPE, err
+		}
+	}
+
+	for i := 0; i < jobNum; i++ {
+		value, ok := segHashMap.Load(i)
+		if !ok {
+			return nil, 0, storageTypes.REDUNDANCY_EC_TYPE, fmt.Errorf("fail to load the segment hash")
+		}
+		segChecksumList = append(segChecksumList, value.([]byte))
+
+		pieceHashes, ok := pieceHashMap.Load(i)
+		if !ok {
+			return nil, 0, storageTypes.REDUNDANCY_EC_TYPE, fmt.Errorf("fail to load the segment hash")
+		}
+		hashValues := pieceHashes.([][]byte)
+		for j := 0; j < len(encodeDataHash); j++ {
+			encodeDataHash[j][i] = hashValues[j]
+		}
+	}
+
+	// combine the hash root of pieces of the PrimarySP
+	hashList[0] = GenerateIntegrityHash(segChecksumList)
+
+	// compute the integrity hash of the SecondarySP
+	spLen := len(encodeDataHash)
+	wg.Add(spLen)
+	for spID, content := range encodeDataHash {
+		go func(data [][]byte, id int) {
+			defer wg.Done()
+			hashList[id+1] = GenerateIntegrityHash(data)
+		}(content, spID)
+	}
+
+	wg.Wait()
+	return hashList, contentLen, storageTypes.REDUNDANCY_EC_TYPE, nil
 }

--- a/go/hash/hash.go
+++ b/go/hash/hash.go
@@ -264,12 +264,15 @@ func computePieceHashes(segment []byte, dataShards, parityShards int) ([][]byte,
 	return pieceChecksumList, nil
 }
 
-func hashWorker(jobs <-chan SegmentInfo, errChan chan<- error, dataShards, parityShards int, wg *sync.WaitGroup, checksumMap *sync.Map, pieceHashMap *sync.Map) {
+// hashWorker receive the segment info and compute the corresponding segment hash and piece hashes.
+// The result will be stored in the sync map to compute integrity hash in order.
+func hashWorker(jobs <-chan SegmentInfo, errChan chan<- error, dataShards, parityShards int, wg *sync.WaitGroup,
+	segmentHashMap *sync.Map, pieceHashMap *sync.Map) {
 	defer wg.Done()
 
 	for segInfo := range jobs {
 		checksum := GenerateChecksum(segInfo.Data)
-		checksumMap.Store(segInfo.SegmentId, checksum)
+		segmentHashMap.Store(segInfo.SegmentId, checksum)
 
 		pieceCheckSumList, err := computePieceHashes(segInfo.Data, dataShards, parityShards)
 		if err != nil {

--- a/go/hash/hash_test.go
+++ b/go/hash/hash_test.go
@@ -28,7 +28,7 @@ func TestHash(t *testing.T) {
 	contentToHash := createTestData(length)
 	start := time.Now()
 
-	hashResult, size, redundancyType, err := ComputeIntegrityHash(contentToHash, int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks, true)
+	hashResult, size, redundancyType, err := ComputeIntegrityHash(contentToHash, int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks, false)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -55,13 +55,13 @@ func TestHash(t *testing.T) {
 		t.Errorf("compute hash num not right")
 	}
 	for _, hash := range hashResult {
-		if len(hash) != 32 {
+		if len(hash) != expectedHashBytesLen {
 			t.Errorf("hash length not right")
 		}
 	}
 }
 
-func TestHashResult(t *testing.T) {
+func TestHashResultSerial(t *testing.T) {
 	var buffer bytes.Buffer
 	line := `1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890`
 
@@ -69,7 +69,7 @@ func TestHashResult(t *testing.T) {
 	for i := 0; i < 1024*1024; i++ {
 		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
 	}
-	hashList, _, _, err := ComputeIntegrityHash(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks, true)
+	hashList, _, _, err := ComputeIntegrityHashSerial(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/go/hash/hash_test.go
+++ b/go/hash/hash_test.go
@@ -28,7 +28,7 @@ func TestHash(t *testing.T) {
 	contentToHash := createTestData(length)
 	start := time.Now()
 
-	hashResult, size, redundancyType, err := ComputeIntegrityHash(contentToHash, int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks)
+	hashResult, size, redundancyType, err := ComputeIntegrityHash(contentToHash, int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks, true)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -69,7 +69,7 @@ func TestHashResult(t *testing.T) {
 	for i := 0; i < 1024*1024; i++ {
 		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
 	}
-	hashList, _, _, err := ComputeIntegrityHash(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks)
+	hashList, _, _, err := ComputeIntegrityHash(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks, true)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -124,27 +124,55 @@ func TestParallelHashResult(t *testing.T) {
 	}
 }
 
+// TestCompareHashResult compare serial and parallel version function hash results with different file size,
+// it is expected that the hash result are same with different version.
 func TestCompareHashResult(t *testing.T) {
 	var buffer bytes.Buffer
-	line := `1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890`
-
-	for i := 0; i < 1024*500; i++ {
+	line := `1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,123456789012`
+	// test file less than 16M
+	for i := 0; i < 1024*100; i++ {
 		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
 	}
+	compareHashResult(buffer, t)
 
-	hashList, _, _, err := ComputeIntegrityHash(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks)
+	buffer.Reset()
+	// test file 100M
+	for i := 0; i < 1024*1024; i++ {
+		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
+	}
+	compareHashResult(buffer, t)
+
+	buffer.Reset()
+	// test file 500M
+	for i := 0; i < 1024*1024*5; i++ {
+		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
+	}
+	compareHashResult(buffer, t)
+
+	// test file 1G
+	for i := 0; i < 1024*1024*10; i++ {
+		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
+	}
+	compareHashResult(buffer, t)
+}
+
+// compareHashResult compare serial and parallel version function hash results
+func compareHashResult(buffer bytes.Buffer, t *testing.T) {
+	start := time.Now()
+	expectedHashList, _, _, err := ComputeIntegrityHash(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks, false)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+	fmt.Println(" serial computing hash cost time:", time.Since(start).Milliseconds(), "ms")
 
-	expectedHashList := hashList
-	hashList, _, _, err = ComputeIntegrityHashParallel(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks)
+	start = time.Now()
+	paralleResult, _, _, err := ComputeIntegrityHashParallel(bytes.NewReader(buffer.Bytes()), int64(segmentSize), redundancy.DataBlocks, redundancy.ParityBlocks)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
+	fmt.Println(" parallel computing hash cost time:", time.Since(start).Milliseconds(), "ms")
 
-	// Compare serial and parallel version results
-	for id, hash := range hashList {
+	for id, hash := range paralleResult {
 		if !bytes.Equal(hash, expectedHashList[id]) {
 			t.Errorf("compare hash error, id: %d, hash1, %s, hash2 %s \n", id, hash, expectedHashList[id])
 		}


### PR DESCRIPTION
### Description

support parallel hash computing before creating object in the client .
The function will utilize multiple threads based on the number of CPU cores of the user's operating system. Considering that the client's computing capability may be limited, the function currently limits the maximum concurrent threads to 5.



test result (mac OS with 6 cpu core ):

**file size  less than 16M**:
 serial computing hash cost time: 92 ms
 parallel computing hash cost time: 88 ms

**file size 100M**:
 serial computing hash cost time: 710 ms
 parallel computing hash cost time: 211 ms

**file size 500M**:
 serial computing hash cost time: 3439 ms
 parallel computing hash cost time: 898 ms


**file size 1G**:
 serial computing hash cost time: 12378 ms
 parallel computing hash cost time: 2378 ms

### Rationale
support computing hash of larger file by a parallel way



### Example

NA

### Changes

Notable changes:
*  support parallel hash

