### PR TITLE
Develop

### DIFF
--- a/go/go.sum
+++ b/go/go.sum
@@ -710,6 +710,8 @@ github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8t
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.9.3/go.mod h1:CwCi+NUr9pqSVktrkN+Ondf06rkhYZ/pcNv7fu+8Un4=
+github.com/klauspost/reedsolomon v1.11.6 h1:h0MUpEzmretucmlelC3EefQHKgk6vWpKz/ctB/tmaEs=
+github.com/klauspost/reedsolomon v1.11.6/go.mod h1:cuXqklb3LNaurR5MVjy7WLXAEUqGz4I0Uc+rnQ7POUg=
 github.com/klauspost/reedsolomon v1.11.8 h1:s8RpUW5TK4hjr+djiOpbZJB4ksx+TdYbRH7vHQpwPOY=
 github.com/klauspost/reedsolomon v1.11.8/go.mod h1:4bXRN+cVzMdml6ti7qLouuYi32KHJ5MGv0Qd8a47h6A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go/go.sum
+++ b/go/go.sum
@@ -710,8 +710,6 @@ github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8t
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.9.3/go.mod h1:CwCi+NUr9pqSVktrkN+Ondf06rkhYZ/pcNv7fu+8Un4=
-github.com/klauspost/reedsolomon v1.11.6 h1:h0MUpEzmretucmlelC3EefQHKgk6vWpKz/ctB/tmaEs=
-github.com/klauspost/reedsolomon v1.11.6/go.mod h1:cuXqklb3LNaurR5MVjy7WLXAEUqGz4I0Uc+rnQ7POUg=
 github.com/klauspost/reedsolomon v1.11.8 h1:s8RpUW5TK4hjr+djiOpbZJB4ksx+TdYbRH7vHQpwPOY=
 github.com/klauspost/reedsolomon v1.11.8/go.mod h1:4bXRN+cVzMdml6ti7qLouuYi32KHJ5MGv0Qd8a47h6A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go/http/const.go
+++ b/go/http/const.go
@@ -21,4 +21,9 @@ const (
 	HTTPHeaderAuthorization   = "Authorization"
 	// MaxExpiryAgeInSec
 	MaxExpiryAgeInSec = 3600 * 24 * 7 // 7 days
+
+	// Gnfd1Ecdsa auth type will use ECDSA-secp256k1 algorithm
+	Gnfd1Ecdsa = "GNFD1-ECDSA"
+	// Gnfd1Eddsa auth type will use EDDSA algorithm for off-chain auth, usually in web applications
+	Gnfd1Eddsa = "GNFD1-EDDSA"
 )

--- a/go/http/const.go
+++ b/go/http/const.go
@@ -26,4 +26,6 @@ const (
 	Gnfd1Ecdsa = "GNFD1-ECDSA"
 	// Gnfd1Eddsa auth type will use EDDSA algorithm for off-chain auth, usually in web applications
 	Gnfd1Eddsa = "GNFD1-EDDSA"
+	// Gnfd1EthPersonalSign auth type will use eth personal sign algorithm. It will only be used in SP update_key API.
+	Gnfd1EthPersonalSign = "GNFD1-ETH-PERSONAL_SIGN"
 )

--- a/go/http/const.go
+++ b/go/http/const.go
@@ -10,9 +10,15 @@ const (
 	HTTPHeaderUnsignedMsg     = "X-Gnfd-Unsigned-Msg"
 
 	HTTPHeaderContentMD5    = "Content-MD5"
-	HTTPHeaderDate          = "X-Gnfd-Date"
 	HTTPHeaderRange         = "Range"
 	HTTPHeaderContentSHA256 = "X-Gnfd-Content-Sha256"
 
 	HTTPHeaderUserAddress = "X-Gnfd-User-Address"
+	// HTTPHeaderDate The date and time format must follow the ISO 8601 standard, and must be formatted with the "yyyyMMddTHHmmssZ" format. For example if the date and time was "08/01/2016 15:32:41.982-700" then it must first be converted to UTC (Coordinated Universal Time) and then submitted as "20160801T223241Z".
+	HTTPHeaderDate = "X-Gnfd-Date"
+	// HTTPHeaderExpiryTimestamp defines the expiry timestamp, which is the ISO 8601 datetime string (e.g. 2021-09-30T16:25:24Z), and the maximum Timestamp since the request sent must be less than MaxExpiryAgeInSec (seven days).
+	HTTPHeaderExpiryTimestamp = "X-Gnfd-Expiry-Timestamp"
+	HTTPHeaderAuthorization   = "Authorization"
+	// MaxExpiryAgeInSec
+	MaxExpiryAgeInSec = 3600 * 24 * 7 // 7 days
 )

--- a/go/http/gen_sign_str.go
+++ b/go/http/gen_sign_str.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
-
-	"github.com/bnb-chain/greenfield-common/go/hash"
 )
 
 var supportHeads = []string{
 	HTTPHeaderContentSHA256, HTTPHeaderTransactionHash, HTTPHeaderObjectID, HTTPHeaderRedundancyIndex, HTTPHeaderResource,
 	HTTPHeaderDate, HTTPHeaderRange, HTTPHeaderPieceIndex, HTTPHeaderContentType, HTTPHeaderContentMD5, HTTPHeaderUnsignedMsg, HTTPHeaderUserAddress,
+	HTTPHeaderExpiryTimestamp,
 }
 
 // getCanonicalHeaders generate a list of request headers with their values
@@ -71,7 +70,8 @@ func getSignedHeaders(req *http.Request, supportHeaders map[string]struct{}) str
 }
 
 // GetCanonicalRequest generate the canonicalRequest base on aws s3 sign without payload hash. t
-func GetCanonicalRequest(req *http.Request, supportHeaders map[string]struct{}) string {
+func GetCanonicalRequest(req *http.Request) string {
+	supportHeaders := initSupportHeaders()
 	req.URL.RawQuery = strings.ReplaceAll(req.URL.Query().Encode(), "+", "%20")
 	canonicalRequest := strings.Join([]string{
 		req.Method,
@@ -85,9 +85,15 @@ func GetCanonicalRequest(req *http.Request, supportHeaders map[string]struct{}) 
 
 // GetMsgToSign generate the msg bytes from canonicalRequest to sign
 func GetMsgToSign(req *http.Request) []byte {
-	headers := initSupportHeaders()
-	signBytes := hash.GenerateChecksum([]byte(GetCanonicalRequest(req, headers)))
-	return crypto.Keccak256(signBytes)
+	return crypto.Keccak256([]byte(GetCanonicalRequest(req)))
+}
+
+// GetMsgToSignForPreSignedURL is only used in SP get Object API.  This util method can be used in by SP side and client side to construct the MsgToSign
+func GetMsgToSignForPreSignedURL(req *http.Request) []byte {
+	queryValues := req.URL.Query()
+	queryValues.Del(HTTPHeaderAuthorization)
+	req.URL.RawQuery = queryValues.Encode()
+	return GetMsgToSign(req)
 }
 
 func initSupportHeaders() map[string]struct{} {


### PR DESCRIPTION
### Description

GNTD auth refactoring 

### Rationale
This is auth refactoring for both the deprecated v1 and off-chain-auth, both of which are renamed as well.

### Example

NA

### Changes

Notable changes:
* https://github.com/bnb-chain/greenfield-common/pull/34  feat: add "X-Gnfd-Expires" header